### PR TITLE
Add a new relationships develops_from

### DIFF
--- a/pronto/relationship.py
+++ b/pronto/relationship.py
@@ -199,6 +199,7 @@ class Relationship(object):
             ...    print(r)
             Relationship('is_a')
             Relationship('part_of')
+            Relationship('develops_from')
 
         """
         return tuple(unique_everseen(r for r in cls._instances.values() if r.direction=='bottomup'))

--- a/pronto/relationship.py
+++ b/pronto/relationship.py
@@ -260,3 +260,7 @@ Relationship('has_units', symmetry=False, transitivity=False,
                           reflexivity=None)
 
 Relationship('has_domain', symmetry=False, transitivity=False)
+
+Relationship('develops_from', symmetry=False, transitivity=True,
+                              reflexivity=True, complementary='can_be',
+                              direction='bottomup')


### PR DESCRIPTION
Thank you for developing your great package. I use this package to analyze an ontology and try to find a new function of my target protein.

In the ontology I am using, there is a new relationship not defined in pronto. The relationship **develops_from** defines a kind of parent-children relationship; If **A** develops_from **B**, every instance of **A** inherited a significant portion of its matter from **B**. Please read [here](http://wiki.plantontology.org/index.php/Relations_in_the_Plant_Ontology#.C2.A0_develops_from) for details.

Therefore, I added a new relathinship to _relationships.py_. If there are no problems, please merge this pull request.

Thanks,
ttyskg