### PR TITLE
Make equality comparison of equivalent instances of `Term` return `True`

### DIFF
--- a/pronto/term.py
+++ b/pronto/term.py
@@ -282,6 +282,10 @@ class Term(object):
             self._rparents[(level, intermediate)] = rparents
             return rparents
 
+    def __hash__(self):
+        """ Hash term """
+        return hash(self.id)
+
     def __eq__(self, other):
         """ Determine if two terms are equal
 
@@ -291,7 +295,7 @@ class Term(object):
         Returns:
             :obj:`bool`: :obj:`True` if the terms are the same
         """
-        return self.id == other.id
+        return self.__class__ == other.__class__ and self.id == other.id
 
 
 class TermList(list):

--- a/pronto/term.py
+++ b/pronto/term.py
@@ -282,6 +282,17 @@ class Term(object):
             self._rparents[(level, intermediate)] = rparents
             return rparents
 
+    def __eq__(self, other):
+        """ Determine if two terms are equal
+
+        Arguments:
+            other (:obj:`Term`): other term
+
+        Returns:
+            :obj:`bool`: :obj:`True` if the terms are the same
+        """
+        return self.id == other.id
+
 
 class TermList(list):
     """A list of `Term` instances.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pronto
-version = 0.12.0a
+version = 0.12.1
 author = Martin Larralde
 author-email = martin.larralde@ens-paris-saclay.fr
 home-page = https://github.com/althonos/pronto

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pronto
-version = 0.12.0
+version = 0.12.0a
 author = Martin Larralde
 author-email = martin.larralde@ens-paris-saclay.fr
 home-page = https://github.com/althonos/pronto

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pronto
-version = 0.12.1
+version = 0.12.2
 author = Martin Larralde
 author-email = martin.larralde@ens-paris-saclay.fr
 home-page = https://github.com/althonos/pronto

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -15,6 +15,7 @@ import gzip
 import os.path as op
 import warnings
 import textwrap
+import copy
 
 from . import utils
 import pronto
@@ -288,6 +289,21 @@ class TestProntoRemoteOntology(TestProntoOntology):
         """
         owl = pronto.Ontology("http://purl.obolibrary.org/obo/xao.owl")
         self.check_ontology(owl)
+
+
+class TermEqualityTestCase(unittest.TestCase):
+    def test(self):
+        obo = pronto.Ontology("http://purl.obolibrary.org/obo/doid.obo")
+        term = obo['DOID:0001816']
+        term_copy = copy.copy(term)
+        self.assertEqual(term, term_copy)
+
+        term_copy = copy.deepcopy(term)
+        self.assertEqual(term, term_copy)
+
+        obo_copy = pronto.Ontology("http://purl.obolibrary.org/obo/doid.obo")
+        term_copy = obo_copy['DOID:0001816']
+        self.assertEqual(term, term_copy)
 
 
 def setUpModule():

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -298,12 +298,21 @@ class TermEqualityTestCase(unittest.TestCase):
         term_copy = copy.copy(term)
         self.assertEqual(term, term_copy)
 
-        term_copy = copy.deepcopy(term)
-        self.assertEqual(term, term_copy)
-
         obo_copy = pronto.Ontology("http://purl.obolibrary.org/obo/doid.obo")
         term_copy = obo_copy['DOID:0001816']
         self.assertEqual(term, term_copy)
+
+    @unittest.expectedFailure
+    def test_demo_deepcopy_bug(self):
+
+        obo = pronto.Ontology("http://purl.obolibrary.org/obo/doid.obo")
+        term = obo['DOID:0001816']
+
+        # pronto doesn't properly implement deepcopy()
+        term_copy = copy.deepcopy(term)
+        self.assertEqual(term, term_copy)
+        term_copy_copy = copy.deepcopy(term_copy)
+        self.assertEqual(term, term_copy_copy)
 
 
 def setUpModule():

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -312,6 +312,7 @@ class TermEqualityTestCase(unittest.TestCase):
         term_copy = copy.deepcopy(term)
         self.assertEqual(term, term_copy)
         term_copy_copy = copy.deepcopy(term_copy)
+        # this assert should succeed, but it fails
         self.assertEqual(term, term_copy_copy)
 
 


### PR DESCRIPTION
With Pronto 0.12.0, comparison of two instances of `Term` returns False even when the two instances have the same `id`. The pull request fixes this issue and adds a test case. The existing tests all still pass.
```
onto = pronto.Ontology('...')
term = onto['id']

onto_copy = pronto.Ontology('...')
term_copy = onto_copy['id']
term == term_copy --> False

term_copy = copy(term)
term == term_copy --> False
```