### PR TITLE
Switch from frozendict to immutabledict

### DIFF
--- a/pronto/relationship.py
+++ b/pronto/relationship.py
@@ -2,7 +2,7 @@ import datetime
 import typing
 from typing import Dict, FrozenSet, Mapping, Optional, Set, Tuple
 
-import frozendict
+import immutabledict
 
 from .entity import Entity, EntityData
 from .definition import Definition
@@ -287,7 +287,7 @@ class Relationship(Entity):
     @property
     def relationships(self) -> Mapping["Relationship", FrozenSet["Relationship"]]:
         ont, reldata = self._ontology(), self._data()
-        return frozendict.frozendict(
+        return immutabledict.immutabledict(
             {
                 ont.get_relationship(rel): frozenset(
                     ont.get_relationship(rel) for rel in rels

--- a/pronto/term.py
+++ b/pronto/term.py
@@ -19,7 +19,7 @@ from typing import (
     AbstractSet,
 )
 
-import frozendict
+import immutabledict
 import networkx
 
 from . import relationship
@@ -383,7 +383,7 @@ class Term(Entity):
     @property
     def relationships(self) -> Mapping[Relationship, FrozenSet["Term"]]:
         ont, termdata = self._ontology(), self._data()
-        return frozendict.frozendict(
+        return immutabledict.immutabledict(
             {
                 Relationship(ont, ont.get_relationship(rel)._data()): frozenset(
                     Term(ont, ont.get_term(term)._data()) for term in terms

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ setup_requires =
 install_requires =
     chardet ~=3.0
     fastobo ~=0.8.2
-    frozendict ~=1.2
+    immutabledict ~=1.0
     networkx ~=2.3
     python-dateutil ~=2.8
 


### PR DESCRIPTION
`frozendict` is broken on the latest versions of Python and the project is dead, see https://github.com/slezica/python-frozendict/pull/30