### PR TITLE
Add get_uri method to term.py class

### DIFF
--- a/pronto/term.py
+++ b/pronto/term.py
@@ -253,6 +253,13 @@ class Term(Entity["TermData", "TermSet"]):
                         yield ont.get_term(other)
             done.add(node)
 
+    def get_uri(self, term, ontology):
+        prefix, local = term.id.split(":")
+        if prefix in ontology.metadata.idspaces:
+            return "{}{}".format(ontology.metadata.idspaces[prefix][0], local)
+        else:
+            return "http://purl.obolibrary.org/obo/{}_{}".format(prefix, local)
+
     @typechecked()
     def superclasses(
         self,


### PR DESCRIPTION
Solving #117, added a method `get_uri()` to `term.py` class. 

@althonos what's your take on this?