### PR TITLE
Implement optional single-threaded pronto

### DIFF
--- a/pronto/parsers/base.py
+++ b/pronto/parsers/base.py
@@ -60,18 +60,18 @@ class BaseParser(abc.ABC):
         if import_depth == 0:
             return dict()
 
+        process = functools.partial(
+            cls.process_import,
+            import_depth=import_depth,
+            basepath=basepath,
+            timeout=timeout,
+        )
+
         if threads is not None and threads == 1:
-            return {i: cls.process_import(i, import_depth=import_depth, basepath=basepath, timeout=timeout) for i in imports}
+            return {i: process(i,) for i in imports}
 
         else:
             from multiprocessing.pool import ThreadPool
-
-            process = functools.partial(
-                cls.process_import,
-                import_depth=import_depth,
-                basepath=basepath,
-                timeout=timeout,
-            )
 
             with ThreadPool(threads) as pool:
                 return dict(pool.map(lambda i: (i, process(i)), imports))

--- a/pronto/parsers/base.py
+++ b/pronto/parsers/base.py
@@ -61,7 +61,7 @@ class BaseParser(abc.ABC):
             return dict()
 
         if threads is not None and threads == 1:
-            return dict([(i, cls.process_import(i, import_depth=import_depth, basepath=basepath, timeout=timeout)) for i in imports])
+            return {i: cls.process_import(i, import_depth=import_depth, basepath=basepath, timeout=timeout) for i in imports}
 
         else:
             from multiprocessing.pool import ThreadPool

--- a/pronto/parsers/base.py
+++ b/pronto/parsers/base.py
@@ -1,6 +1,5 @@
 import abc
 import functools
-import multiprocessing.pool
 import operator
 import os
 import typing
@@ -66,8 +65,8 @@ class BaseParser(abc.ABC):
             basepath=basepath,
             timeout=timeout,
         )
-        with multiprocessing.pool.ThreadPool(threads) as pool:
-            return dict(pool.map(lambda i: (i, process(i)), imports))
+
+        return dict([(i, cls.process_import(i, import_depth=import_depth, basepath=basepath, timeout=timeout)) for i in imports])
 
     _entities = {
         "Term": operator.attrgetter("terms", "_terms"),

--- a/pronto/parsers/base.py
+++ b/pronto/parsers/base.py
@@ -68,7 +68,7 @@ class BaseParser(abc.ABC):
         )
 
         if threads is not None and threads == 1:
-            return {i: process(i,) for i in imports}
+            return {i: process(i) for i in imports}
 
         else:
             from multiprocessing.pool import ThreadPool

--- a/pronto/parsers/base.py
+++ b/pronto/parsers/base.py
@@ -60,7 +60,10 @@ class BaseParser(abc.ABC):
         if import_depth == 0:
             return dict()
 
-        if threads:
+        if threads is not None and threads == 1:
+            return dict([(i, cls.process_import(i, import_depth=import_depth, basepath=basepath, timeout=timeout)) for i in imports])
+
+        else:
             from multiprocessing.pool import ThreadPool
 
             process = functools.partial(
@@ -72,8 +75,6 @@ class BaseParser(abc.ABC):
 
             with ThreadPool(threads) as pool:
                 return dict(pool.map(lambda i: (i, process(i)), imports))
-        else:
-            return dict([(i, cls.process_import(i, import_depth=import_depth, basepath=basepath, timeout=timeout)) for i in imports])
 
     _entities = {
         "Term": operator.attrgetter("terms", "_terms"),

--- a/pronto/parsers/obo.py
+++ b/pronto/parsers/obo.py
@@ -1,4 +1,3 @@
-import multiprocessing.pool
 import os
 
 import fastobo
@@ -38,8 +37,8 @@ class OboParser(FastoboParser, BaseParser):
         # Extract frames from the current document.
         with typechecked.disabled():
             try:
-                with multiprocessing.pool.ThreadPool(threads) as pool:
-                    pool.map(self.extract_entity, doc)
+                for single in doc:
+                    self.extract_entity(single)
             except SyntaxError as s:
                 location = self.ont.path, s.lineno, s.offset, s.text
                 raise SyntaxError(s.args[0], location) from None

--- a/pronto/parsers/obo.py
+++ b/pronto/parsers/obo.py
@@ -37,14 +37,15 @@ class OboParser(FastoboParser, BaseParser):
         # Extract frames from the current document.
         with typechecked.disabled():
             try:
-                if threads:
+                if threads is not None and threads == 1:
+                    for single in doc:
+                        self.extract_entity(single)
+
+                else:
                     from multiprocessing.pool import ThreadPool
 
                     with ThreadPool(threads) as pool:
                         pool.map(self.extract_entity, doc)
-                else:
-                    for single in doc:
-                        self.extract_entity(single)
 
             except SyntaxError as s:
                 location = self.ont.path, s.lineno, s.offset, s.text

--- a/pronto/parsers/obo.py
+++ b/pronto/parsers/obo.py
@@ -37,8 +37,15 @@ class OboParser(FastoboParser, BaseParser):
         # Extract frames from the current document.
         with typechecked.disabled():
             try:
-                for single in doc:
-                    self.extract_entity(single)
+                if threads:
+                    from multiprocessing.pool import ThreadPool
+
+                    with ThreadPool(threads) as pool:
+                        pool.map(self.extract_entity, doc)
+                else:
+                    for single in doc:
+                        self.extract_entity(single)
+
             except SyntaxError as s:
                 location = self.ont.path, s.lineno, s.offset, s.text
                 raise SyntaxError(s.args[0], location) from None

--- a/pronto/parsers/obojson.py
+++ b/pronto/parsers/obojson.py
@@ -1,4 +1,3 @@
-import multiprocessing.pool
 import os
 
 import fastobo
@@ -39,8 +38,8 @@ class OboJSONParser(FastoboParser, BaseParser):
         # Extract frames from the current document.
         with typechecked.disabled():
             try:
-                with multiprocessing.pool.ThreadPool(threads) as pool:
-                    pool.map(self.extract_entity, doc)
+                for single in doc:
+                    self.extract_entity(single)
             except SyntaxError as err:
                 location = self.ont.path, err.lineno, err.offset, err.text
                 raise SyntaxError(err.args[0], location) from None

--- a/pronto/parsers/obojson.py
+++ b/pronto/parsers/obojson.py
@@ -38,8 +38,15 @@ class OboJSONParser(FastoboParser, BaseParser):
         # Extract frames from the current document.
         with typechecked.disabled():
             try:
-                for single in doc:
-                    self.extract_entity(single)
+                if threads:
+                    from multiprocessing.pool import ThreadPool
+
+                    with ThreadPool(threads) as pool:
+                        pool.map(self.extract_entity, doc)
+                else:
+                    for single in doc:
+                        self.extract_entity(single)
+
             except SyntaxError as err:
                 location = self.ont.path, err.lineno, err.offset, err.text
                 raise SyntaxError(err.args[0], location) from None

--- a/pronto/parsers/obojson.py
+++ b/pronto/parsers/obojson.py
@@ -38,14 +38,14 @@ class OboJSONParser(FastoboParser, BaseParser):
         # Extract frames from the current document.
         with typechecked.disabled():
             try:
-                if threads:
+                if threads is not None and threads == 1:
+                    for single in doc:
+                        self.extract_entity(single)
+                else:
                     from multiprocessing.pool import ThreadPool
 
                     with ThreadPool(threads) as pool:
                         pool.map(self.extract_entity, doc)
-                else:
-                    for single in doc:
-                        self.extract_entity(single)
 
             except SyntaxError as err:
                 location = self.ont.path, err.lineno, err.offset, err.text


### PR DESCRIPTION
This PR comes from me attempting to use pronto in AWS Lambda. AWS Lambda does not support the python multiprocessing module because AWS Lambda operates in a stateless environment and does not support threading.

I have modified the code to not use the multiprocessing module if the kwarg `threads == 1`. 

This will allow pronto to operate in both a single-threaded and multi-threaded mode. 