### PR TITLE
Fix KeyError when accessing lineage dictionary in OBO parser

### DIFF
--- a/pronto/parsers/base.py
+++ b/pronto/parsers/base.py
@@ -85,7 +85,10 @@ class BaseParser(abc.ABC):
                 graphdata.lineage.setdefault(entity.id, Lineage())
             for subentity, lineage in graphdata.lineage.items():
                 for superentity in lineage.sup:
-                    graphdata.lineage[superentity].sub.add(subentity)
+                    if superentity in graphdata.lineage:
+                        graphdata.lineage[superentity].sub.add(subentity)
+                    else:
+                        print(f"Warning: {superentity} not found in lineage.")
 
     def import_lineage(self):
         for getter in self._entities.values():


### PR DESCRIPTION
### Description
This pull request addresses an issue where accessing the lineage dictionary resulted in a KeyError if the superentity was not found. 

### Changes Made
- Implemented a conditional check to ensure that the superentity exists in the lineage dictionary before accessing it.
- Added a warning message to inform users when a superentity is not found, improving the robustness of the parser.

### Motivation
This change enhances error handling in the OBO parser, making it more resilient to inconsistencies in the ontology files and providing clearer feedback to users during debugging.